### PR TITLE
fix #8 issue.

### DIFF
--- a/app/src/main/java/com/example/android/mygarden/ui/PlantListAdapter.java
+++ b/app/src/main/java/com/example/android/mygarden/ui/PlantListAdapter.java
@@ -83,7 +83,6 @@ public class PlantListAdapter extends RecyclerView.Adapter<PlantListAdapter.Plan
 
     public void swapCursor(Cursor newCursor)
     {
-        Log.d(TAG, "swapCursor: cursor: "+newCursor.isClosed());
         if (mCursor != null && mCursor != newCursor)
         {
             mCursor.close();

--- a/app/src/main/java/com/example/android/mygarden/ui/PlantListAdapter.java
+++ b/app/src/main/java/com/example/android/mygarden/ui/PlantListAdapter.java
@@ -81,8 +81,11 @@ public class PlantListAdapter extends RecyclerView.Adapter<PlantListAdapter.Plan
         holder.plantImageView.setTag(plantId);
     }
 
-    public void swapCursor(Cursor newCursor) {
-        if (mCursor != null) {
+    public void swapCursor(Cursor newCursor)
+    {
+        Log.d(TAG, "swapCursor: cursor: "+newCursor.isClosed());
+        if (mCursor != null && mCursor != newCursor)
+        {
             mCursor.close();
         }
         mCursor = newCursor;


### PR DESCRIPTION
The problem was that after inserting a new planet the cursor updated instead of creating new cursor, then on the swapCursor function, the old cursor (which is also the new cursor) was closed and then when we tried to read the content out of the new cursor (also the old cursor) we got an exception since the cursor was closed.

**NOTE:**
The real solution is to rebase this commit and squash it with the Starter_Code commit, but this action would affect all the users that using this repo, so I recommend each user to rebase this issue on it's local repo