### PR TITLE
Fix #8, 'cursor is deactivated prior to calling this method' error.

### DIFF
--- a/app/src/main/java/com/example/android/mygarden/ui/MainActivity.java
+++ b/app/src/main/java/com/example/android/mygarden/ui/MainActivity.java
@@ -91,4 +91,10 @@ public class MainActivity
         Intent intent = new Intent(this, AddPlantActivity.class);
         startActivity(intent);
     }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        getSupportLoaderManager().restartLoader(GARDEN_LOADER_ID, null, this);
+    }
 }


### PR DESCRIPTION
When you add a new plant or navigate back from the details activity the application will crash. You have to restart the loader in `onRestart()`.